### PR TITLE
Fix filter apply

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -331,6 +331,15 @@ function start() {
                             delete rule.settings[0]['text-buffer'];
                           }
 
+                          let placementId = 4;
+                          if (pprcssng) {
+                            placementId = 4;
+                          } else if (style.name === 'label_roads_name') {
+                            placementId = 3;
+                          } else {
+                            placementId = 2;
+                          }
+
                           // settings placement
                           const placementData = [
                             {
@@ -361,7 +370,7 @@ function start() {
                                 overrunDistanceUnit: 'MM',
                                 centroidWhole: '0',
                                 offsetType: '0',
-                                placement: pprcssng === true ? '4' : '2', // 2 parallel, 4 horizontal
+                                placement: placementId, // 2 parallel, 3, curved, 4 horizontal
                                 priority: '0',
                                 geometryGenerator: '',
                                 polygonPlacementFlags: '2',

--- a/src/app.js
+++ b/src/app.js
@@ -234,7 +234,7 @@ function start() {
                         } else {
                           pprcssng = false;
                           if (scales.length === 0 && style.rules.length > 0) {
-                            style.rules.forEach((rule) => {
+                            style.rules.forEach((rule, i) => {
                               if (rule.scaleDenominator) {
                                 for (let j = 0; j < rule.symbolizers.length; j += 1) {
                                   scales.push(
@@ -246,7 +246,9 @@ function start() {
                                         ? rule.scaleDenominator.min
                                         : null,
                                       filter: rule.filter !== undefined
-                                        ? checkForFnStrMatches(rule.filter)
+                                        ? checkForFnStrMatches(
+                                          result.qgis.labeling[0].rules[0].rule[i].$.filter,
+                                        )
                                         : null,
                                     },
                                   );


### PR DESCRIPTION
This MR
- fixes filter apply for QGIS rules on text symbolizers
- uses curved placement for `label_roads_name`